### PR TITLE
Recipe filter bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea
+.vscode

--- a/src/components/CategoriesList.js
+++ b/src/components/CategoriesList.js
@@ -23,11 +23,9 @@ const CategoriesList = ({ categories, onChange }) => {
             temp[index] = "transparent"
             tempFont[index] = "black"
             tempSelected = tempSelected.filter(item => item !== categories[index])
-            tempSelected.splice(index, 1)
             setColour(temp)
             setFontColour(tempFont)
             setCategoriesSelected(tempSelected)
-            console.log("temp",tempSelected)
         
         } else {
             temp[index] = "#ffc53b"

--- a/src/components/Recipe.js
+++ b/src/components/Recipe.js
@@ -11,7 +11,7 @@ const Recipe = ({ recipeTitle, recipeDescription, recipePicture }) => {
         setTitle(recipeTitle)
         setDescription(recipeDescription)
         setPicture(recipePicture)
-    }, [])
+    }, [recipeTitle])
 
     return ( 
         <div className={styles.container} >

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -6,23 +6,19 @@ import { useEffect, useState, useRef } from "react";
 
 
 const Wrapper = () => {
-
     const [recipes, setRecipes] = useState([])
     const [recipesSelected, setRecipesSelected] = useState([])
     const [categories, setCategories] = useState([])
     const [filters, setFilters] = useState([]);
 
-
-     const handleFilterChange = (newValue) => {
-        setFilters(newValue)
-      }
+    const handleFilterChange = (newValue) => {
+      setFilters(newValue)
+    }
       
-
-      /**
-     * useEffect that fetches the recipes
-     * from the getAll endpoint.
+    /**
+     * useEffect that updates the selected recipes on a filter change
      */
-      let tempArray =[]
+    let tempArray =[]
     useEffect(() => {
         if (filters.length == 0) {
             tempArray = recipes
@@ -41,10 +37,9 @@ const Wrapper = () => {
 
 
     /**
-     * useEffect that fetches the categories
-     * from the getAll endpoint.
+     * useEffect that fetches the categories and recipes
+     * from their getAll endpoints.
      */
-
      useEffect(() => {
         fetch("http://localhost:5001/api/categories/getAll")
           .then(response => response.json())
@@ -87,7 +82,6 @@ const Wrapper = () => {
                 <RecipesList 
                     recipes={recipesSelected}
                     filters={filters} />
-
             </div>
         </div>
      );

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -8,13 +8,13 @@ import { useEffect, useState, useRef } from "react";
 const Wrapper = () => {
 
     const [recipes, setRecipes] = useState([])
+    const [recipesSelected, setRecipesSelected] = useState([])
     const [categories, setCategories] = useState([])
     const [filters, setFilters] = useState([]);
 
 
      const handleFilterChange = (newValue) => {
         setFilters(newValue)
-        console.log(newValue)
       }
       
 
@@ -23,41 +23,21 @@ const Wrapper = () => {
      * from the getAll endpoint.
      */
       let tempArray =[]
-      let trigger
     useEffect(() => {
-        fetch("http://localhost:5001/api/recipes/getAll")
-        .then(response => response.json())
-        .then(res =>{
-            //  console.log(res)  
-            //  setRecipes(res)
-            //  filters.includes(res.map(r => r.categories.map(c => c.stringName)))
-            //  console.log(recipes)
+        if (filters.length == 0) {
+            tempArray = recipes
+        } else {
+          for (let i = 0; i < recipes.length; i++) {
+              for (let j = 0; j < filters.length; j++) {
+                  if (recipes[i].categories.map(c => c.stringName).includes(filters[j].stringName)) {
+                      tempArray.push(recipes[i])  
+                  }
+              } 
+            }
+        }
 
-             if (filters.length == 0) {
-                 tempArray = res
-             } else {
-                for (let i = 0; i < recipes.length; i++) {
-                    for (let j = 0; j < filters.length; j++) {
-                        // console.log("for loops are ran more than once")
-                        if (res[i].categories.map(c => c.stringName).includes(filters[j].stringName)) {
-                            tempArray.push(res[i])  
-                                
-                        }
-                    } 
-                 }
-             }
-            setRecipes(tempArray)
-            // console.log(tempArray)
-
-  
-            })
+      setRecipesSelected(tempArray)
     }, [filters])
-
- 
-
-    // useEffect(() => {
-    //     setRecipes(tempArray)
-    // }, [trigger])
 
 
     /**
@@ -67,11 +47,17 @@ const Wrapper = () => {
 
      useEffect(() => {
         fetch("http://localhost:5001/api/categories/getAll")
-        .then(response => response.json())
-        .then(res =>{            
-             setCategories(res)
+          .then(response => response.json())
+          .then(res =>{            
+              setCategories(res)
+          })
 
-            })
+        fetch("http://localhost:5001/api/recipes/getAll")
+          .then(response => response.json())
+          .then(res =>{            
+              setRecipes(res)
+              setRecipesSelected(res)
+          })
     }, [])
 
 
@@ -83,7 +69,6 @@ const Wrapper = () => {
         previousValues.current.recipes !== recipes
       ) {
 
-        console.log("both changed")
         previousValues.current = { filters, recipes };
       }
     });
@@ -100,7 +85,7 @@ const Wrapper = () => {
             
             <div className={styles.recipeContainer}>
                 <RecipesList 
-                    recipes={recipes}
+                    recipes={recipesSelected}
                     filters={filters} />
 
             </div>

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -3,6 +3,7 @@ import RecipesList from "./RecipesList";
 import RecipeMessage from "./RecipeMessage";
 import styles from '../styling/Wrapper.module.css'
 import { useEffect, useState, useRef } from "react";
+import constants from '../util/constants'
 
 
 const Wrapper = () => {
@@ -41,13 +42,13 @@ const Wrapper = () => {
      * from their getAll endpoints.
      */
      useEffect(() => {
-        fetch("http://localhost:5001/api/categories/getAll")
+        fetch(constants.allCategories())
           .then(response => response.json())
           .then(res =>{            
               setCategories(res)
           })
 
-        fetch("http://localhost:5001/api/recipes/getAll")
+        fetch(constants.allRecipes())
           .then(response => response.json())
           .then(res =>{            
               setRecipes(res)

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -1,0 +1,46 @@
+const endpoints = require('./endpoints.json');
+
+function allCategories() {
+  return getEndpoint('categories', 'getAll')
+}
+
+function allRecipes() {
+  return getEndpoint('recipes', 'getAll')
+}
+
+/**
+ * Gets the full endpoint for a given entity and query
+ * @param {String} entities The entities you are referring to. Must be one of the following: "categories", "recipes"
+ * @param {String} query The type of query you want. Must be one of the following: "getAll"
+ * @returns 
+ */
+function getEndpoint(entities, query) {
+  // When moving to production, add a check here to determine whether
+  // this is being called from a dev or prod environment
+  const environment = true ? 'dev' : 'prod'
+
+  // prefix is the location of the host (for example http://localhost:5001/api)
+  const prefix = true ? endpoints.dev.prefix : endpoints.prod.prefix
+
+  if (!prefix) {
+    throw "Invalid prefix"
+  }
+
+  // http://localhost:5001/api/entities
+  const entity = endpoints[environment][entities]
+
+  if (!entity) {
+    throw "Invalid entity"
+  }
+
+  // http://localhost:5001/api/entities/getAll
+  const url = entity[query]
+
+  if (!url) {
+    throw "Invalid query"
+  }
+
+  return prefix.concat(url)
+}
+
+module.exports = {allCategories, allRecipes}

--- a/src/util/endpoints.json
+++ b/src/util/endpoints.json
@@ -1,0 +1,20 @@
+{
+  "dev": {
+    "prefix": "http://localhost:5001/api",
+    "categories": {
+      "getAll": "/categories/getAll"
+    },
+    "recipes": {
+      "getAll": "/recipes/getAll"
+    }
+  },
+  "prod": {
+    "prefix": "",
+    "categories": {
+      "getAll": ""
+    },
+    "recipes": {
+      "getAll": ""
+    }
+  }
+}


### PR DESCRIPTION
## Commits

- Fixed filter bug
- Added idea and vscode folders
- Added a comment
- Abstracted urls to the constants file


## Notes on the changes

- Added new state variable `recipesSelected`. This is what actually get's displayed on the screen.
    This change is to avoid making new requests to the server everytime the filters change as was the case before.

- The old `recipes` variable is now only set once which is when the page loads and is then queried to determine the former.

- Created `constants.js` and `endpoints.json` to abstract URLs away from the component files. This should come in handy when the project moves to production.


Note that `endpoints.json` should the following structure:

```json
"dev/prod": {
  "prefix": "http://***/api",
  "entityNameInPlural": {
    "endPoint1": "/entityNameInPlural/***"
  }
}
```